### PR TITLE
Fix issue where docs of the new version are not published

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,3 +16,9 @@ jobs:
     uses: ./.github/workflows/build-and-publish.yml
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+  publish-docs:
+    needs: [ cd-job ]
+    name: Publish Documentation
+    uses: ./.github/workflows/gh-pages.yml
+

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+## 🐞 Fixed
+
+* Fixed the issue with publishing new documentation after releasing a new version

--- a/exasol/toolbox/templates/github/workflows/cd.yml
+++ b/exasol/toolbox/templates/github/workflows/cd.yml
@@ -16,3 +16,9 @@ jobs:
     uses: ./.github/workflows/build-and-publish.yml
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+  publish-docs:
+    needs: [ cd-job ]
+    name: Publish Documentation
+    uses: ./.github/workflows/gh-pages.yml
+


### PR DESCRIPTION
Previously, the documentation for the new version had not been published as part of the release. The new docs were only released with the next PR merge after the release was completed. This time gap can be significant. Therefore, releasing the docs has now been made a step in the CD process itself.

# ✔ Checklist

* [X] Have you updated the changelog?
* [ ] Have you updated the cookiecutter-template?
* [X] Are you mentioning the issue which this PullRequest fixes ("Fixes...")

Note: If any of the above is not relevant to your PR just check the box.
