### PR TITLE
Add `__version__` member to `version.py`

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -2,6 +2,7 @@
 
 ## 🔧 Changed
 
+* Add `__version__` member to generated `version.py` for comatibility with other versions schemes
 * Excluded pyupgrade from project check due to its destructive nature
 * Updated cookiecutter template
     - removed obsolete template file `version.html`

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -2,7 +2,7 @@
 
 ## 🔧 Changed
 
-* Add `__version__` member to generated `version.py` for comatibility with other versions schemes
+* Add `__version__` member to generated `version.py` for compatibility with other versions schemes
 * Excluded pyupgrade from project check due to its destructive nature
 * Updated cookiecutter template
     - removed obsolete template file `version.html`

--- a/exasol/toolbox/pre_commit_hooks/package_version.py
+++ b/exasol/toolbox/pre_commit_hooks/package_version.py
@@ -32,6 +32,7 @@ _VERSION_MODULE_TEMPLATE = cleandoc('''
     MINOR = {minor}
     PATCH = {patch}
     VERSION = f"{{MAJOR}}.{{MINOR}}.{{PATCH}}"
+    __version__ = VERSION
 ''') + "\n"
 # fmt: on
 

--- a/exasol/toolbox/version.py
+++ b/exasol/toolbox/version.py
@@ -8,3 +8,4 @@ MAJOR = 0
 MINOR = 18
 PATCH = 0
 VERSION = f"{MAJOR}.{MINOR}.{PATCH}"
+__version__ = VERSION

--- a/project-template/{{cookiecutter.repo_name}}/exasol/{{cookiecutter.package_name}}/version.py
+++ b/project-template/{{cookiecutter.repo_name}}/exasol/{{cookiecutter.package_name}}/version.py
@@ -8,3 +8,4 @@ MAJOR = 0
 MINOR = 1
 PATCH = 0
 VERSION = f"{MAJOR}.{MINOR}.{PATCH}"
+__version__ = VERSION


### PR DESCRIPTION
In order to improve compatibility with other version schemes, this alternative label for the version was added to the version file.

# ✔ Checklist

* [X] Have you updated the changelog?
* [x] Have you updated the cookiecutter-template?

Note: If any of the above is not relevant to your PR just check the box.
