### PR TITLE
Fix double execution of CI workflow on initial PR push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
       - "gh-pages/*"
       - "main"
       - "master"
-  pull_request:
-    types: [opened, reopened]
   schedule:
     # “At 00:00 on every 7th day-of-month from 1 through 31.” (https://crontab.guru)
     - cron: "0 0 1/7 * *"

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,1 +1,7 @@
 # Unreleased
+
+## 🐞 Fixed
+* Fixed an issue in the CI workflow that caused it to be executed twice on the initial push of a PR if the PR branch was on the repo itself.
+
+    🚨 Attention: Due to these changes, the workflows will no longer be executed if the PR comes from a branch not located in this repository.
+                  As third-party contributions from outside forks are rare to nearly non-existent, this downside was considered a reasonable trade-off at this time.

--- a/exasol/toolbox/templates/github/workflows/ci.yml
+++ b/exasol/toolbox/templates/github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
       - "gh-pages/*"
       - "main"
       - "master"
-  pull_request:
-    types: [opened, reopened]
   schedule:
     # “At 00:00 on every 7th day-of-month from 1 through 31.” (https://crontab.guru)
     - cron: "0 0 1/7 * *"


### PR DESCRIPTION
# ✔ Checklist

* [X] Have you updated the changelog?
* [X] Have you updated the cookiecutter-template?

Note: If any of the above is not relevant to your PR just check the box.
