### PR TITLE
Resolve pydantic config warnings

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,4 +1,7 @@
 # Unreleased
 
+## Refactoring
+* Switched deprecated Pydantic class-based `config` to `ConfigDict`
+
 ## Security
 * #477: Switched `sonar:check` to use `SONAR_TOKEN` from the environment

--- a/exasol/toolbox/util/dependencies/poetry_dependencies.py
+++ b/exasol/toolbox/util/dependencies/poetry_dependencies.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import re
 import subprocess
-import sys
 from pathlib import Path
 from typing import Optional
 
 import tomlkit
 from pydantic import (
     BaseModel,
+    ConfigDict,
 )
 from tomlkit import TOMLDocument
 
@@ -16,22 +15,19 @@ from exasol.toolbox.util.dependencies.shared_models import Package
 
 
 class PoetryGroup(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     name: str
     toml_section: Optional[str]
-
-    class Config:
-        frozen = True
 
 
 TRANSITIVE_GROUP = PoetryGroup(name="transitive", toml_section=None)
 
 
 class PoetryToml(BaseModel):
-    content: TOMLDocument
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
-    class Config:
-        frozen = True
-        arbitrary_types_allowed = True
+    content: TOMLDocument
 
     @classmethod
     def load_from_toml(cls, working_directory: Path) -> PoetryToml:

--- a/exasol/toolbox/util/dependencies/shared_models.py
+++ b/exasol/toolbox/util/dependencies/shared_models.py
@@ -3,17 +3,16 @@ from __future__ import annotations
 from packaging.version import Version
 from pydantic import (
     BaseModel,
+    ConfigDict,
     field_validator,
 )
 
 
 class Package(BaseModel):
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     name: str
     version: Version
-
-    class Config:
-        frozen = True
-        arbitrary_types_allowed = True
 
     @field_validator("version", mode="before")
     def convert_version(cls, v: str) -> Version:


### PR DESCRIPTION
Thanks to @Jannis-Mittenzwei for noticing these log warnings we had missed when running tests

```bash
.cache/pypoetry/virtualenvs/exasol-toolbox-HhsxY0p2-py3.13/lib/python3.13/site-packages/pydantic/_internal/_config.py:323: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
```