### PR TITLE
Remove `lint:dependencies` usage from `report.yml` and add deprecation notice

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -48,9 +48,3 @@ jobs:
         env:
           SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}"
         run: poetry run -- nox -s sonar:check
-
-      - name: Generate GitHub Summary
-        id: generate-github-summary
-        run: |-
-          echo -e "# Summary\n" >> $GITHUB_STEP_SUMMARY
-          poetry run -- nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,3 +1,7 @@
 # Unreleased
 
 ## Summary
+
+## Refactoring
+
+* #924: Removed `lint:dependencies` usage from `report.yml` and added deprecation notice

--- a/exasol/toolbox/nox/_lint.py
+++ b/exasol/toolbox/nox/_lint.py
@@ -14,6 +14,10 @@ from exasol.toolbox.nox._shared import get_filtered_python_files
 from exasol.toolbox.util.dependencies.shared_models import PoetryFiles
 from noxconfig import PROJECT_CONFIG
 
+# The relevant nox session will be removed in:
+#   https://github.com/exasol/python-toolbox/issues/924
+LINT_DEPENDENCIES_DEPRECATION_DATE = "2026-10-08"
+
 
 def _pylint(session: Session, files: Iterable[str]) -> None:
     json_file = PROJECT_CONFIG.root_path / ".lint.json"
@@ -149,6 +153,10 @@ def dependency_check(session: Session) -> None:
     if illegal := dependencies.illegal:
         report_illegal(illegal, console)
         sys.exit(1)
+    session.warn(
+        f"Warning: `nox -s lint:dependencies` is deprecated and will be removed on "
+        f"{LINT_DEPENDENCIES_DEPRECATION_DATE}."
+    )
 
 
 @nox.session(name="lint:import", python=False)

--- a/exasol/toolbox/templates/github/workflows/report.yml
+++ b/exasol/toolbox/templates/github/workflows/report.yml
@@ -47,9 +47,3 @@ jobs:
         env:
           SONAR_TOKEN: "${{ secrets.(( sonar_token_name )) }}"
         run: poetry run -- nox -s sonar:check
-
-      - name: Generate GitHub Summary
-        id: generate-github-summary
-        run: |
-          echo -e "# Summary\n" >> $GITHUB_STEP_SUMMARY
-          poetry run -- nox -s dependency:licenses >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
relates to #924 

# Checklist

Note: If any of the items in the checklist are not relevant to your PR, just check the box.

## For any Pull Request

Is the following correct:
* [x] the title of the Pull Request?
* [x] the title of the corresponding issue?
* [x] there are no other open [Pull Requests](../../../../pulls) for the same update/change? <!-- markdown-link-check-disable-line -->
* [x] that the issue which this Pull Request fixes ("Fixes...") is mentioned?

## When Changes Were Made

Did you:
* [x] update the changelog?
* [ ] update the cookiecutter-template?
* [x] update the implementation?
* [ ] check coverage and add tests: unit tests and, if relevant, integration tests?
* [x ] update the User Guide & other documentation?
* [x] resolve any failing CI criteria (incl. Sonar quality gate)?

## When Preparing a Release

Have you:
* [ ] thought about version number (major, minor, patch)?
* [ ] checked Exasol packages for updates and resolved open vulnerabilities, if easily possible?
